### PR TITLE
replace naive_navigate with safe_step

### DIFF
--- a/hlt/common.py
+++ b/hlt/common.py
@@ -1,3 +1,5 @@
+import logging
+
 # Placed here to avoid circular imports
 def read_input():
     """

--- a/hlt/networking.py
+++ b/hlt/networking.py
@@ -34,6 +34,7 @@ class Game:
             filemode="w",
             level=log_level,
         )
+        logging.info("Logs configured!")
 
         self.players = {}
         for player in range(num_players):

--- a/run_game.sh
+++ b/run_game.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./halite --replay-directory replays/ -vvv --width 32 --height 32 "python3 MyBot.py" "python3 IncumbentBot.py"
+./halite --replay-directory replays/ -vvv --width 32 --height 32 "python3 MyBot.py" "python3 MyBot.py"


### PR DESCRIPTION
With `naive_navigate`, I was getting stuck into "gridlock" ([reminds me of this Dr Seuss story](https://www.google.com/imgres?imgurl=https%3A%2F%2Fvignette.wikia.nocookie.net%2Fseuss%2Fimages%2F3%2F3c%2FThe-zax-300x225.gif%2Frevision%2Flatest%3Fcb%3D20130206183418&imgrefurl=http%3A%2F%2Fseuss.wikia.com%2Fwiki%2FThe_Zax&docid=vaa6FZsowXpc4M&tbnid=7IMLCmvNJWuoLM%3A&vet=1&w=300&h=225&bih=944&biw=1680&ved=0ahUKEwjxgLjK8OXeAhWDTt8KHQf1BacQMwhTKAkwCQ&iact=c&ictx=1))

`safe_step` is a replacement, which takes in a path, not a target. I'm thinking longer term I don't have to compute paths on every ship turn, but can stagger path computation with other decisions. The logic is similar, but in the event of the preferred tile being occupied (or about to be), it selects a random direction. This won't completely prevent gridlock, but should greatly reduce the likelihood of it occurring